### PR TITLE
fix typo in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -25,8 +25,8 @@ Send fluent-event as message to amazon SNS.
       sns_topic_name {sns_topic_name}
 
       # following attibutes are optional
-    　
-      sqs_endpoint {endpointURL}
+
+      sns_endpoint {endpointURL}
 
       ### endpoint list ###
       # Asia Pacific (Tokyo) [Default] : sns.ap-northeast-1.amazonaws.com


### PR DESCRIPTION
remove a double-byte space and fix typo in README.rdoc.
