### PR TITLE
Add secret parameters

### DIFF
--- a/lib/fluent/plugin/out_sns.rb
+++ b/lib/fluent/plugin/out_sns.rb
@@ -12,8 +12,8 @@ module Fluent
     include SetTimeKeyMixin
     config_set_default :include_time_key, true
 
-    config_param :aws_key_id, :string, :default => nil
-    config_param :aws_sec_key, :string, :default => nil
+    config_param :aws_key_id, :string, :default => nil, :secret => true
+    config_param :aws_sec_key, :string, :default => nil, :secret => true
 
     config_param :sns_topic_name, :string
     config_param :sns_subject_template, :default => nil


### PR DESCRIPTION
Fluentd's config_params now supports concealing given parameters with xxxxxx.
If using fluentd dose not provide this concealing feature, it will be simply ignored.

Currently, this repository depends fluentd 0.10.x, so, this parameters are simply ignored.