### PR TITLE
Specify aws-sdk version1

### DIFF
--- a/fluent-plugin-sns.gemspec
+++ b/fluent-plugin-sns.gemspec
@@ -31,14 +31,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<fluentd>, ["~> 0.10.0"])
-      s.add_runtime_dependency(%q<aws-sdk>, ["~> 1.3.2"])
+      s.add_runtime_dependency(%q<aws-sdk-v1>, ["~> 1"])
     else
       s.add_dependency(%q<fluentd>, ["~> 0.10.0"])
-      s.add_dependency(%q<aws-sdk>, ["~> 1.3.2"])
+      s.add_dependency(%q<aws-sdk-v1>, ["~> 1"])
     end
   else
     s.add_dependency(%q<fluentd>, ["~> 0.10.0"])
-    s.add_dependency(%q<aws-sdk>, ["~> 1.3.2"])
+    s.add_dependency(%q<aws-sdk-v1>, ["~> 1"])
   end
 end
 

--- a/lib/fluent/plugin/out_sns.rb
+++ b/lib/fluent/plugin/out_sns.rb
@@ -1,6 +1,6 @@
 module Fluent
 
-  require 'aws-sdk'
+  require 'aws-sdk-v1'
 
   class SNSOutput < Output
 


### PR DESCRIPTION
This plugin depends on version 1 of `aws-sdk`. So, it needs to specify `aws-sdk-v1` for coexisting with v2.
