### PR TITLE
Add support for Fluentd v0.12 and v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Changelog
 
-### 3.0.0 (unreleased)
+### (unreleased)
+
+- Add support for fluentd v0.12 and v0.14 (#14)
+
+### 3.1.0
 
 - Use AWS SDK v2: this should work the same as with AWS SDK v1, the only
   IMPORTANT change is that `sns_endpoint` has been replaced by `sns_region`

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
     gemspec.homepage = "https://github.com/ixixi/fluent-plugin-sns"
     gemspec.has_rdoc = false
     gemspec.require_paths = ["lib"]
-    gemspec.add_dependency "fluentd", "~> 0.10.0"
+    gemspec.add_dependency "fluentd", ">= 0.10.0", "< 2"
     gemspec.add_dependency "aws-sdk", "~> 2"
     gemspec.test_files = Dir["test/**/*.rb"]
     gemspec.files = Dir["lib/**/*", "test/**/*.rb"] + %w[VERSION AUTHORS Rakefile]

--- a/lib/fluent/plugin/out_sns.rb
+++ b/lib/fluent/plugin/out_sns.rb
@@ -1,3 +1,6 @@
+require 'fluent/output'
+
+
 module Fluent
 
   require 'aws-sdk'


### PR DESCRIPTION
This implements #14. 

Note that we are still using the old Fluentd API (not the new v0.14 API), which is still supported and will be obsoleted in v2.

For more info see:

* http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12
* http://www.fluentd.org/blog/fluentd-v0.14.0-has-been-released (see the
  "New Plugin APIs" chapter)

I did some basic manual tests with Fluentd v0.10, v0.12 and v0.14 and it seems to be working fine. Would be nice to have some automated tests moving forward though.