### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
     gemspec.homepage = "https://github.com/ixixi/fluent-plugin-sns"
     gemspec.has_rdoc = false
     gemspec.require_paths = ["lib"]
-    gemspec.add_dependency "fluentd", ">= 0.10.0", "< 2"
+    gemspec.add_dependency "fluentd", ">= 0.14.0", "< 2"
     gemspec.add_dependency "aws-sdk", "~> 2"
     gemspec.test_files = Dir["test/**/*.rb"]
     gemspec.files = Dir["lib/**/*", "test/**/*.rb"] + %w[VERSION AUTHORS Rakefile]


### PR DESCRIPTION
I've tested with the following config:

```aconf
<source>
  @type forward
</source>
<match sns.**>
  @type sns
  sns_topic_name "MY_TOPIC"
  aws_key_id xxxxxx
  aws_sec_key xxxxxx
  sns_region "MY_AWS_REGION"
  sns_subject_key "from"
  sns_body_template "body_template.erb"
</match>
```