### PR TITLE
Use aws-sdk v3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
     gemspec.has_rdoc = false
     gemspec.require_paths = ["lib"]
     gemspec.add_dependency "fluentd", ">= 0.10.0", "< 2"
-    gemspec.add_dependency "aws-sdk", "~> 2"
+    gemspec.add_dependency "aws-sdk-sns", "~> 1.5"
     gemspec.test_files = Dir["test/**/*.rb"]
     gemspec.files = Dir["lib/**/*", "test/**/*.rb"] + %w[VERSION AUTHORS Rakefile]
     gemspec.executables = []

--- a/fluent-plugin-sns.gemspec
+++ b/fluent-plugin-sns.gemspec
@@ -31,14 +31,13 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<fluentd>, ["< 2", ">= 0.10.0"])
-      s.add_runtime_dependency(%q<aws-sdk>, ["~> 3"])
+      s.add_runtime_dependency(%q<aws-sdk-sns>, ["~> 1.5"])
     else
       s.add_dependency(%q<fluentd>, ["< 2", ">= 0.10.0"])
-      s.add_dependency(%q<aws-sdk>, ["~> 3"])
+      s.add_dependency(%q<aws-sdk-sns>, ["~> 1.5"])
     end
   else
     s.add_dependency(%q<fluentd>, ["< 2", ">= 0.10.0"])
-    s.add_dependency(%q<aws-sdk>, ["~> 3"])
+    s.add_dependency(%q<aws-sdk-sns>, ["~> 1.5"])
   end
 end
-

--- a/fluent-plugin-sns.gemspec
+++ b/fluent-plugin-sns.gemspec
@@ -31,14 +31,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<fluentd>, ["< 2", ">= 0.10.0"])
-      s.add_runtime_dependency(%q<aws-sdk>, ["~> 2"])
+      s.add_runtime_dependency(%q<aws-sdk>, ["~> 3"])
     else
       s.add_dependency(%q<fluentd>, ["< 2", ">= 0.10.0"])
-      s.add_dependency(%q<aws-sdk>, ["~> 2"])
+      s.add_dependency(%q<aws-sdk>, ["~> 3"])
     end
   else
     s.add_dependency(%q<fluentd>, ["< 2", ">= 0.10.0"])
-    s.add_dependency(%q<aws-sdk>, ["~> 2"])
+    s.add_dependency(%q<aws-sdk>, ["~> 3"])
   end
 end
 

--- a/lib/fluent/plugin/out_sns.rb
+++ b/lib/fluent/plugin/out_sns.rb
@@ -1,10 +1,7 @@
 require 'fluent/output'
-
+require 'aws-sdk-sns'
 
 module Fluent
-
-  require 'aws-sdk'
-
   class SNSOutput < Output
 
     Fluent::Plugin.register_output('sns', self)


### PR DESCRIPTION
Use v3 of the AWS SDK. This was the easiest way to upgrade, but potentially only the `aws-sdk-sns` gem should be installed.